### PR TITLE
JDBCのdriverを外から指定できるようにした。

### DIFF
--- a/embulk-output-redshift/README.md
+++ b/embulk-output-redshift/README.md
@@ -10,8 +10,9 @@ Redshift output plugin for Embulk loads records to Redshift.
 
 ## Configuration
 
-- **host**: database host name (string, required)
-- **port**: database port number (integer, default: 5439)
+- **url**: jdbc connecting url (string, required)
+- **driver_path**: path to the jar file of the JDBC driver (e.g. 'sqlite-jdbc-3.8.7.jar') (string, optional)
+- **driver_class**: class name of the JDBC driver (e.g. 'org.sqlite.JDBC') (string, required)
 - **user**: database login user name (string, required)
 - **ssl**: use SSL to connect to the database (string, default: "disable". "enable" uses SSL without server-side validation and "verify" checks the certificate. For compatibility reasons, "true" behaves as "enable" and "false" behaves as "disable".)
 - **password**: database login password (string, default: "")

--- a/embulk-output-redshift/src/main/java/org/embulk/output/RedshiftOutputPlugin.java
+++ b/embulk-output-redshift/src/main/java/org/embulk/output/RedshiftOutputPlugin.java
@@ -29,12 +29,16 @@ public class RedshiftOutputPlugin
 
     public interface RedshiftPluginTask extends AwsCredentialsTaskWithPrefix, PluginTask
     {
-        @Config("host")
-        public String getHost();
 
-        @Config("port")
-        @ConfigDefault("5439")
-        public int getPort();
+        @Config("url")
+        public String getUrl();
+
+        @Config("driver_path")
+        @ConfigDefault("null")
+        public Optional<String> getDriverPath();
+
+        @Config("driver_class")
+        public String getDriverClass();
 
         @Config("user")
         public String getUser();
@@ -106,9 +110,11 @@ public class RedshiftOutputPlugin
     {
         RedshiftPluginTask t = (RedshiftPluginTask) task;
 
-        String url = String.format("jdbc:postgresql://%s:%d/%s",
-                t.getHost(), t.getPort(), t.getDatabase());
-
+        String url = t.getUrl();
+        String driverClass = t.getDriverClass();
+        if (t.getDriverPath().isPresent()) {
+            loadDriverJar(t.getDriverPath().get());
+        }
         Properties props = new Properties();
         props.setProperty("loginTimeout",   "300"); // seconds
         props.setProperty("socketTimeout", "1800"); // seconds
@@ -141,8 +147,12 @@ public class RedshiftOutputPlugin
         props.setProperty("user", t.getUser());
         logger.info("Connecting to {} options {}", url, props);
         props.setProperty("password", t.getPassword());
-
-        return new RedshiftOutputConnector(url, props, t.getSchema());
+        try {
+            return new RedshiftOutputConnector(url, props, t.getSchema(), driverClass);
+        }catch (ClassNotFoundException | InstantiationException | IllegalAccessException e){
+            e.printStackTrace();
+        }
+        return null;
     }
 
     private static AWSCredentialsProvider getAWSCredentialsProvider(RedshiftPluginTask task)

--- a/embulk-output-redshift/src/main/java/org/embulk/output/RedshiftOutputPlugin.java
+++ b/embulk-output-redshift/src/main/java/org/embulk/output/RedshiftOutputPlugin.java
@@ -4,6 +4,7 @@ import java.util.Properties;
 import java.io.IOException;
 import java.sql.SQLException;
 
+import com.google.common.base.Throwables;
 import org.embulk.output.jdbc.MergeConfig;
 import org.slf4j.Logger;
 import com.google.common.base.Optional;
@@ -147,12 +148,7 @@ public class RedshiftOutputPlugin
         props.setProperty("user", t.getUser());
         logger.info("Connecting to {} options {}", url, props);
         props.setProperty("password", t.getPassword());
-        try {
-            return new RedshiftOutputConnector(url, props, t.getSchema(), driverClass);
-        }catch (ClassNotFoundException | InstantiationException | IllegalAccessException e){
-            e.printStackTrace();
-        }
-        return null;
+        return new RedshiftOutputConnector(url, props, t.getSchema(), driverClass);
     }
 
     private static AWSCredentialsProvider getAWSCredentialsProvider(RedshiftPluginTask task)

--- a/embulk-output-redshift/src/main/java/org/embulk/output/redshift/RedshiftOutputConnector.java
+++ b/embulk-output-redshift/src/main/java/org/embulk/output/redshift/RedshiftOutputConnector.java
@@ -4,8 +4,10 @@ import java.util.Properties;
 import java.sql.Driver;
 import java.sql.Connection;
 import java.sql.SQLException;
+
+import com.google.common.base.Throwables;
 import org.embulk.output.jdbc.JdbcOutputConnector;
-import org.embulk.output.jdbc.JdbcOutputConnection;
+
 
 public class RedshiftOutputConnector
         implements JdbcOutputConnector
@@ -16,12 +18,16 @@ public class RedshiftOutputConnector
     private final Properties properties;
     private final String schemaName;
 
-    public RedshiftOutputConnector(String url, Properties properties, String schemaName, String driverClass) throws ClassNotFoundException, InstantiationException, IllegalAccessException
-    {
+    public RedshiftOutputConnector(String url, Properties properties, String schemaName, String driverClass) {
         this.url = url;
         this.properties = properties;
         this.schemaName = schemaName;
-        this.driver = (Driver)Class.forName(driverClass).newInstance();
+        try {
+            this.driver = (Driver) Class.forName(driverClass).newInstance();
+        } catch (ClassNotFoundException | InstantiationException | IllegalAccessException e){
+            throw Throwables.propagate(e);
+        }
+
     }
 
     @Override

--- a/embulk-output-redshift/src/main/java/org/embulk/output/redshift/RedshiftOutputConnector.java
+++ b/embulk-output-redshift/src/main/java/org/embulk/output/redshift/RedshiftOutputConnector.java
@@ -10,17 +10,18 @@ import org.embulk.output.jdbc.JdbcOutputConnection;
 public class RedshiftOutputConnector
         implements JdbcOutputConnector
 {
-    private static final Driver driver = new org.postgresql.Driver();
+    private final Driver driver;
 
     private final String url;
     private final Properties properties;
     private final String schemaName;
 
-    public RedshiftOutputConnector(String url, Properties properties, String schemaName)
+    public RedshiftOutputConnector(String url, Properties properties, String schemaName, String driverClass) throws ClassNotFoundException, InstantiationException, IllegalAccessException
     {
         this.url = url;
         this.properties = properties;
         this.schemaName = schemaName;
+        this.driver = (Driver)Class.forName(driverClass).newInstance();
     }
 
     @Override


### PR DESCRIPTION
amazon製のjdbc driverを使用できるようにするため、外からjdbc のdriverを指定できるようにした。

 * host, portオプションを廃止
 * url, driver_path, driver_classオプションの追加
    * 既存のembulk-output-jdbcと同じ指定の仕方。